### PR TITLE
Add TLS cert regeneration scripts

### DIFF
--- a/t/certs-and-keys/my.conf
+++ b/t/certs-and-keys/my.conf
@@ -1,0 +1,21 @@
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[dn]
+C = CZ
+ST = Central Bohemia
+L = Prague
+O = CA
+OU = IT
+CN = localhost
+emailAddress = foo@example.net
+
+[req_ext]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost

--- a/t/certs-and-keys/tls.sh
+++ b/t/certs-and-keys/tls.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Generate self signed root CA cert
+openssl req -days 365 -config my.conf -nodes -x509 -newkey rsa:4096 -keyout ca.key -out ca-crt.pem -subj "/C=CZ/ST=Central Bohemia/L=Prague/O=CA/OU=IT/CN=localhost/emailAddress=foo@example.net"
+
+# Generate server cert to be signed
+openssl req -nodes -newkey rsa:4096 -keyout server-key.pem -out server.csr -subj "/C=CZ/ST=Central Bohemia/L=Prague/O=foo/OU=IT/CN=localhost/emailAddress=foo@example.net"
+
+# Sign the server cert
+openssl x509 -req -days 365 -in server.csr -CA ca-crt.pem -CAkey ca.key -CAcreateserial -out server-crt.pem -extensions req_ext -extfile my.conf
+
+# Clean up extra files
+rm ca-crt.srl ca.key server.csr
+
+# Verify certs validate correctly
+echo "-----"
+echo "Verifying certs"
+openssl verify -CAfile ca-crt.pem ca-crt.pem
+openssl verify -CAfile ca-crt.pem server-crt.pem


### PR DESCRIPTION
Based on jnthn's and Altai-man's work from this gist, updated with my fixes
for new OpenSSL and CA requirements as of late 2020:

    https://gist.github.com/Altai-man/17a30b60ad9350f7f0a1641798131bf5

I placed them in the t/certs-and-keys/ directory because:

1. We don't want them in bin/, which is for Raku programs and gets installed
   into the user's Raku bindir.
2. No need to deal with directory gymnastics, the script just operates on the
   local dir.
3. They're easy to find when someone has (inevitably after a year) forgotten
   where the regeneration scripts are.  :-)