### PR TITLE
Add version to Cro::Core dependency

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
     "tags"          : [ "SSL", "TLS" ],
     "authors"       : [ "Jonathan Worthington <jnthn@jnthn.net>" ],
     "license"       : "Artistic-2.0",
-    "depends"       : [ "Cro::Core", "IO::Socket::Async::SSL" ],
+    "depends"       : [ "Cro::Core:ver<0.8.5+>", "IO::Socket::Async::SSL" ],
     "provides"      : {
         "Cro::TLS": "lib/Cro/TLS.pm6"
     },


### PR DESCRIPTION
If Cro::Core 0.8.5 is not installed, then Cro::TLS 0.8.5 fails due to missing Cro::TCP::NoDelay